### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ When resizing the browser window or viewing on a small-screen device, the body e
 
 # Typography
 
-You may set the body font size and line height with the `$fontsize` and `$lineheight` variables in `_core.scss`. Heading sizes are calulated with the Golden Ratio based on the body font size, like this:
+You may set the body font size and line height with the `$fontsize` and `$lineheight` variables in `_core.scss`. Heading sizes are calculated with the Golden Ratio based on the body font size, like this:
 
 	h1{
 		font-size: $fontsize*1.618*1.618;


### PR DESCRIPTION
@johanbrook, I've corrected a typographical error in the documentation of the [dyluni](https://github.com/johanbrook/dyluni) project. Specifically, I've changed calulate to calculate. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
